### PR TITLE
Fix 200 status error response for refreshing access tokens

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   docker-build:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/main'
     steps:
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v2

--- a/src/main/java/de/unistuttgart/iste/meitrex/user_service/service/AccessTokenService.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/user_service/service/AccessTokenService.java
@@ -130,7 +130,7 @@ public class AccessTokenService {
             return new AccessToken(accessToken.getAccessToken(), accessToken.getExternalUserId());
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) Thread.currentThread().interrupt();
-            log.error("Failed to refresh access token for user {} and provider {}", accessToken.getUserId(), provider, e);
+            log.error("Failed to refresh access token for user {} and provider {}", accessToken.getUserId(), provider);
         }
         return null;
     }
@@ -168,7 +168,7 @@ public class AccessTokenService {
             }
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) Thread.currentThread().interrupt();
-            log.error("Failed to generate access token for user {} and provider {}", currentUserInfo.getId(), provider, e);
+            log.error("Failed to generate access token for user {} and provider {}", currentUserInfo.getId(), provider);
         }
         return false;
     }

--- a/src/main/java/de/unistuttgart/iste/meitrex/user_service/service/oauth/GitHubOAuthStrategy.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/user_service/service/oauth/GitHubOAuthStrategy.java
@@ -84,14 +84,17 @@ public class GitHubOAuthStrategy implements ExternalOAuthStrategy {
 
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
-        JsonObject json = JsonParser.parseString(response.body()).getAsJsonObject();
-
-        if (response.statusCode() == 200 && !json.has("error")) {
-            return parseTokenResponse(response.body());
+        if (response.statusCode() != 200) {
+            log.error("Failed to exchange code. HTTP {} Body: {}", response.statusCode(), response.body());
+            return null;
         }
 
-        log.error("Failed to exchange code for access token. HTTP Status: {} Response: {}", response.statusCode(), response.body());
-        return null;
+        try {
+            return parseTokenResponse(response.body());
+        } catch (Exception ex) {
+            log.error("Non-JSON or malformed token response body: {}", response.body(), ex);
+            return null;
+        }
     }
 
     @Override
@@ -109,17 +112,25 @@ public class GitHubOAuthStrategy implements ExternalOAuthStrategy {
                 .build();
 
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-        JsonObject json = JsonParser.parseString(response.body()).getAsJsonObject();
 
-        if (response.statusCode() == 200) {
-            log.error("Failed to refresh access token. HTTP Status: {} Response: {}", response.statusCode(), response.body());
-            return parseTokenResponse(response.body());
-            
+        if (response.statusCode() != 200) {
+            log.error("Failed to refresh token. HTTP {} Body: {}", response.statusCode(), response.body());
+            return null;
         }
 
-        log.error("Failed to refresh access token. HTTP Status: {} Response: {}", response.statusCode(), response.body());
-        return null;
+        try {
+            JsonObject json = JsonParser.parseString(response.body()).getAsJsonObject();
+            if (json.has("error")) {
+                log.error("GitHub refresh error: {}", json);
+                return null;
+            }
+            return parseTokenResponse(response.body());
+        } catch (Exception ex) {
+            log.error("Non-JSON or malformed refresh response body: {}", response.body(), ex);
+            return null;
+        }
     }
+
 
     public String fetchExternalUserId(String accessToken) throws IOException, InterruptedException {
         HttpRequest request = HttpRequest.newBuilder()

--- a/src/main/java/de/unistuttgart/iste/meitrex/user_service/service/oauth/GitHubOAuthStrategy.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/user_service/service/oauth/GitHubOAuthStrategy.java
@@ -84,7 +84,9 @@ public class GitHubOAuthStrategy implements ExternalOAuthStrategy {
 
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
-        if (response.statusCode() == 200) {
+        JsonObject json = JsonParser.parseString(response.body()).getAsJsonObject();
+
+        if (response.statusCode() == 200 && !json.has("error")) {
             return parseTokenResponse(response.body());
         }
 
@@ -107,6 +109,7 @@ public class GitHubOAuthStrategy implements ExternalOAuthStrategy {
                 .build();
 
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        JsonObject json = JsonParser.parseString(response.body()).getAsJsonObject();
 
         if (response.statusCode() == 200) {
             log.error("Failed to refresh access token. HTTP Status: {} Response: {}", response.statusCode(), response.body());

--- a/src/main/java/de/unistuttgart/iste/meitrex/user_service/service/oauth/GitHubOAuthStrategy.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/user_service/service/oauth/GitHubOAuthStrategy.java
@@ -109,8 +109,9 @@ public class GitHubOAuthStrategy implements ExternalOAuthStrategy {
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
         if (response.statusCode() == 200) {
-            return parseTokenResponse(response.body());
             log.error("Failed to refresh access token. HTTP Status: {} Response: {}", response.statusCode(), response.body());
+            return parseTokenResponse(response.body());
+            
         }
 
         log.error("Failed to refresh access token. HTTP Status: {} Response: {}", response.statusCode(), response.body());

--- a/src/main/java/de/unistuttgart/iste/meitrex/user_service/service/oauth/GitHubOAuthStrategy.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/user_service/service/oauth/GitHubOAuthStrategy.java
@@ -110,6 +110,7 @@ public class GitHubOAuthStrategy implements ExternalOAuthStrategy {
 
         if (response.statusCode() == 200) {
             return parseTokenResponse(response.body());
+            log.error("Failed to refresh access token. HTTP Status: {} Response: {}", response.statusCode(), response.body());
         }
 
         log.error("Failed to refresh access token. HTTP Status: {} Response: {}", response.statusCode(), response.body());

--- a/src/main/java/de/unistuttgart/iste/meitrex/user_service/service/oauth/GitHubOAuthStrategy.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/user_service/service/oauth/GitHubOAuthStrategy.java
@@ -92,7 +92,7 @@ public class GitHubOAuthStrategy implements ExternalOAuthStrategy {
         try {
             return parseTokenResponse(response.body());
         } catch (Exception ex) {
-            log.error("Non-JSON or malformed token response body: {}", response.body(), ex);
+            log.error("Non-JSON or malformed token response body: {}", response.body());
             return null;
         }
     }
@@ -126,7 +126,7 @@ public class GitHubOAuthStrategy implements ExternalOAuthStrategy {
             }
             return parseTokenResponse(response.body());
         } catch (Exception ex) {
-            log.error("Non-JSON or malformed refresh response body: {}", response.body(), ex);
+            log.error("Non-JSON or malformed refresh response body: {}", response.body());
             return null;
         }
     }

--- a/src/test/java/de/unistuttgart/iste/meitrex/user_service/service/AccessTokenServiceTest.java
+++ b/src/test/java/de/unistuttgart/iste/meitrex/user_service/service/AccessTokenServiceTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 class AccessTokenServiceTest {
 
@@ -100,12 +101,17 @@ class AccessTokenServiceTest {
     }
 
     @Test
-    void testIsAccessTokenAvailable_ExpiredToken_ValidRefreshToken() {
+    void testIsAccessTokenAvailable_ExpiredToken_ValidRefreshToken() throws Exception{
         validAccessToken.setAccessToken("valid_access_token");
         validAccessToken.setAccessTokenExpiresAt(OffsetDateTime.now().minusMinutes(5));
         validAccessToken.setRefreshToken("refresh_token");
         validAccessToken.setRefreshTokenExpiresAt(OffsetDateTime.now().plusMinutes(5));
         when(accessTokenRepository.findByUserIdAndProvider(any(), any())).thenReturn(Optional.of(validAccessToken));
+
+        AccessTokenResponse refreshed = new AccessTokenResponse(
+                "new_valid_access_token", /* expiresIn */ 3600, "new_refresh", /* refreshExpiresIn */ 7200);
+        when(externalOAuthClient.refreshAccessToken(eq("refresh_token"), any()))
+                .thenReturn(refreshed);
 
         Boolean result = accessTokenService.isAccessTokenAvailable(loggedInUser, providerDto);
 


### PR DESCRIPTION
## Description of changes
Fix the issue with GH when refreshing access tokens. Sometimes instead of the correct response one gets 200 bad_refresh_token response, see https://github.com/orgs/community/discussions/24745.

  
## How has this been tested?

- [x] automated unit test
- [ ] automated integration test
- [ ] manual, exploratory test

In case of manual test, please document the test well including a set of user instructions and prerequisites. Each including an action, it's result, and where appropriate a screenshot.
    
## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/MEITREX/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
